### PR TITLE
Relax constraints on include directory naming.

### DIFF
--- a/detail/hirschberg.hpp
+++ b/detail/hirschberg.hpp
@@ -3,7 +3,7 @@
 #ifndef STEP_HIRSCHBERG_HPP
 #define STEP_HIRSCHBERG_HPP
 
-#include <step/detail/utility.hpp>
+#include "utility.hpp"
 
 namespace step::hirschberg {
 

--- a/edit_distance.hpp
+++ b/edit_distance.hpp
@@ -4,7 +4,7 @@
 #define STEP_EDIT_DISTANCE_HPP
 
 #include <optional>
-#include <step/detail/hirschberg.hpp>
+#include "detail/hirschberg.hpp"
 
 namespace step::edit_distance {
 namespace detail {

--- a/longest_common_subsequence.hpp
+++ b/longest_common_subsequence.hpp
@@ -3,7 +3,7 @@
 #ifndef STEP_LONGEST_COMMON_SUBSEQUENCE_HPP
 #define STEP_LONGEST_COMMON_SUBSEQUENCE_HPP
 
-#include <step/detail/hirschberg.hpp>
+#include "detail/hirschberg.hpp"
 
 namespace step::longest_common_subsequence {
 namespace detail {

--- a/longest_common_substring.hpp
+++ b/longest_common_substring.hpp
@@ -3,8 +3,8 @@
 #ifndef STEP_LONGEST_COMMON_SUBSTRING_HPP
 #define STEP_LONGEST_COMMON_SUBSTRING_HPP
 
-#include <step/suffix_array.hpp>
-#include <step/suffix_tree.hpp>
+#include "suffix_array.hpp"
+#include "suffix_tree.hpp"
 
 namespace step::longest_common_substring {
 namespace detail {

--- a/longest_repeated_substring.hpp
+++ b/longest_repeated_substring.hpp
@@ -3,8 +3,8 @@
 #ifndef STEP_LONGEST_REPEATED_SUBSTRING_HPP
 #define STEP_LONGEST_REPEATED_SUBSTRING_HPP
 
-#include <step/suffix_array.hpp>
-#include <step/suffix_tree.hpp>
+#include "suffix_array.hpp"
+#include "suffix_tree.hpp"
 
 namespace step::longest_repeated_substring {
 namespace detail {

--- a/suffix_array.hpp
+++ b/suffix_array.hpp
@@ -3,7 +3,7 @@
 #ifndef STEP_SUFFIX_ARRAY_HPP
 #define STEP_SUFFIX_ARRAY_HPP
 
-#include <step/detail/utility.hpp>
+#include "detail/utility.hpp"
 
 namespace step {
 

--- a/suffix_tree.hpp
+++ b/suffix_tree.hpp
@@ -5,7 +5,7 @@
 
 #include <optional>
 #include <stack>
-#include <step/detail/utility.hpp>
+#include "detail/utility.hpp"
 #include <unordered_map>
 
 namespace step {


### PR DESCRIPTION
With this change, the `.hpp` files can find the includes in the `detail/`
directory without necessarily being in a directory called `step`.