### PR TITLE
Fix compiler warning about uninitialised member.

### DIFF
--- a/suffix_array.hpp
+++ b/suffix_array.hpp
@@ -42,7 +42,7 @@ public:
     explicit suffix_array(std::vector<T>&& str)
         : str_(std::move(str)), idx_(size())
     {
-        auto generator = [i = Size{}]() mutable { return suffix{i++}; };
+        auto generator = [i = Size{}]() mutable { return suffix{i++,{}}; };
         auto pos = [](auto& suf) { return suf.pos; };
         auto val = [&](auto& suf) { return str_[suf.pos]; };
         auto by_rank = [](auto& l, auto& r) { return l.rank < r.rank; };


### PR DESCRIPTION
This is the warning GCC emits:

```
../3rdparty/step/suffix_array.hpp:45:69: warning: missing initializer for member ‘step::suffix_array<char,
long unsigned int, std::less<void> >::suffix::rank’ [-Wmissing-field-initializers]
   45 |         auto generator = [i = Size{0}]() mutable { return suffix{i++}; };
      |                                                                     ^
```